### PR TITLE
[run.py] - Serve via Waitress (https://pypi.org/project/waitress/) instead of Werkzeug when not in debug mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Werkzeug==2.0.3
 pip>=19.1.1
 APScheduler==3.6.0
 click==7.1.2
@@ -16,6 +15,9 @@ ptyprocess==0.6.0
 pytz==2018.9
 requests>=2.21.0
 setuptools>=40.6.3
-six>=1.12.0
-SQLAlchemy==1.4.49 
-w3lib>=1.17.0
+six==1.16.0
+SQLAlchemy==1.3.24
+tzlocal==1.5.1
+w3lib==2.0.0
+Werkzeug==2.0.0
+waitress

--- a/scrapydweb/__init__.py
+++ b/scrapydweb/__init__.py
@@ -159,7 +159,7 @@ def handle_db(app):
     app.config['SQLALCHEMY_DATABASE_URI'] = SQLALCHEMY_DATABASE_URI
     app.config['SQLALCHEMY_BINDS'] = SQLALCHEMY_BINDS
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False  # https://stackoverflow.com/a/33790196/10517783
-    app.config['SQLALCHEMY_ECHO'] = True  # http://flask-sqlalchemy.pocoo.org/2.3/config/
+    app.config['SQLALCHEMY_ECHO'] = False  # http://flask-sqlalchemy.pocoo.org/2.3/config/
 
     # flask_sqlalchemy/__init__.py
     # class SQLAlchemy(object):

--- a/setup.py
+++ b/setup.py
@@ -33,19 +33,29 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=[
-        "Werkzeug == 2.0.3",
-        "APScheduler >= 3.5.3",  # Aug 15, 2018
-        "flask >= 1.0.2",  # May 2, 2018
-        "flask-compress >= 1.4.0",  # Jan 5, 2017
-        "Flask-SQLAlchemy >= 2.3.2",  # Oct 11, 2017
-        "logparser == 0.8.2",
-        "requests >= 2.21.0",  # Dec 10, 2018
-        "setuptools >= 40.6.3",  # Dec 11, 2018
-        "six >= 1.12.0",  # Dec 10, 2018
-        "SQLAlchemy == 1.4.49 ",  # Dec 12, 2018
-        "w3lib >= 1.17.0",  # Feb 9, 2017
+        "APScheduler==3.6.0",  # Mar 18, 2019
+        "click==7.1.2",  # Apr 28, 2020
+        "colorama==0.4.0",  # Oct 10, 2018
+        "Flask==2.0.0",  # May 12, 2021
+        "Flask-Compress==1.4.0",  # Jan 5, 2017
+        "Flask-SQLAlchemy==2.4.0",  # Apr 25, 2019
+        "idna==2.7",  # Jun 11, 2018
+        "itsdangerous==2.0.0",  # May 12, 2021
+        "Jinja2==3.0.0",  # May 12, 2021
+        "logparser>=0.8.4",
+        "MarkupSafe==2.0.0",  # May 12, 2021
+        "pexpect==4.7.0",  # Apr 7, 2019
+        "ptyprocess==0.6.0",  # Jun 22, 2018
+        "pytz==2018.9",  # Jan 7, 2019
+        "requests>=2.21.0",  # Dec 10, 2018
+        "setuptools>=40.6.3",  # Dec 11, 2018
+        "six==1.16.0",  # May 5, 2021
+        "SQLAlchemy==1.3.24",  # Mar 31, 2021
+        "tzlocal==1.5.1",  # Dec 1, 2017
+        "w3lib==2.0.0",  # Aug 11, 2022
+        "Werkzeug==2.0.0",  # May 12, 2021
+        "waitress"
     ],
-
     entry_points={
         "console_scripts": {
             "scrapydweb = scrapydweb.run:main"


### PR DESCRIPTION
[Run flask app with Production server](https://flask.palletsprojects.com/en/stable/tutorial/deploy/#run-with-a-production-server)

[Any of these would work](https://flask.palletsprojects.com/en/stable/deploying/), [Waitress](https://pypi.org/project/waitress/) depends only on standard library and should be good enough.

_Dependencies were out of sync with upstream, changed back so they are the same - Everything seems OK_